### PR TITLE
Env variable api dev port

### DIFF
--- a/client-deliberation/docker-compose.yml
+++ b/client-deliberation/docker-compose.yml
@@ -19,6 +19,6 @@ services:
       context: .
       dockerfile: Dockerfile-dev
     ports:
-      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:8081:8081"
     volumes:
       - ./src:/app/src

--- a/client-deliberation/docker-compose.yml
+++ b/client-deliberation/docker-compose.yml
@@ -1,0 +1,24 @@
+# note that this doesn't yet work properly when running all the containers
+# containers using `make start`.
+
+# This is because we need to host this container in dev mode in order to
+# get hot reload functionality. However, the file server is also hosted
+# on port 8080, and the system is designed for all static content to be
+# build and hosted via a file server on the same port. So we need to find
+# a way to create a proxy for the API calls, because everything is supposed to
+# be on the same hostname + port, but that's not going to work in development.
+
+# ports should be kept as they are, if they are changed it seems that
+# it breaks hot reload functonality within the container
+
+services:
+  client-deliberation:
+    env_file:
+      - "../.env"
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    ports:
+      - "127.0.0.1:8080:8080"
+    volumes:
+      - ./src:/app/src

--- a/client-deliberation/src/util/url.js
+++ b/client-deliberation/src/util/url.js
@@ -1,4 +1,6 @@
 // Copyright (C) 2012-present, The Authors. This program is free software: you can redistribute it and/or  modify it under the terms of the GNU Affero General Public License, version 3, as published by the Free Software Foundation. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// frontend can send requests to a different port via environment var
 const host = process.env.DEV_PORT_OVERRIDE ? 
   `${document.location.hostname}:${process.env.DEV_PORT_OVERRIDE}`
   : document.location.host;

--- a/client-deliberation/src/util/url.js
+++ b/client-deliberation/src/util/url.js
@@ -1,6 +1,9 @@
 // Copyright (C) 2012-present, The Authors. This program is free software: you can redistribute it and/or  modify it under the terms of the GNU Affero General Public License, version 3, as published by the Free Software Foundation. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+const host = process.env.DEV_PORT_OVERRIDE ? 
+  `${document.location.hostname}:${process.env.DEV_PORT_OVERRIDE}`
+  : document.location.host;
 
-const urlPrefix = `${document.location.protocol}//${document.location.host}/`
+const urlPrefix = `${document.location.protocol}//${host}/`
 
 export default {
   urlPrefix,

--- a/client-deliberation/webpack.config.js
+++ b/client-deliberation/webpack.config.js
@@ -19,6 +19,7 @@ var cliArgs = mri(argv)
 
 var enableTwitterWidgets = process.env.ENABLE_TWITTER_WIDGETS === 'true';
 var fbAppId = process.env.FB_APP_ID;
+var devPortOverride = process.env.DEV_PORT_OVERRIDE;
 
 module.exports = (env, options) => {
   var isDevBuild = options.mode === 'development';
@@ -72,6 +73,7 @@ module.exports = (env, options) => {
       }),
       new webpack.DefinePlugin({
         'process.env.FB_APP_ID': JSON.stringify(fbAppId),
+        'process.env.DEV_PORT_OVERRIDE': JSON.stringify(devPortOverride),
       }),
       // Only run analyzer when specified in flag.
       ...(cliArgs.analyze ? [new BundleAnalyzerPlugin({ defaultSizes: 'gzip' })] : []),

--- a/client-deliberation/webpack.config.js
+++ b/client-deliberation/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = (env, options) => {
     },
     devServer: {
       historyApiFallback: true,
+      port: 8081,
       /**
       // TODO: Set up API proxy later for server component.
       // See: https://webpack.js.org/configuration/dev-server/#devserverproxy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,3 +61,13 @@ services:
   #     live-code-reloaded ports
   #   * leave the server pointing to the static builds, but have separate ports you can hit for the live-code
   #     reloading (making sure to document the process)
+  client-deliberation:
+    env_file:
+      - ".env"
+    build:
+      context: ./client-deliberation
+      dockerfile: Dockerfile-dev
+    ports:
+      - "127.0.0.1:8081:8081"
+    volumes:
+      - ./client-deliberation/src:/app/src


### PR DESCRIPTION
By default API requests are sent to the same port from which they are issued. This works if all files are served from the file-server container. But we want hot reload ability in a client-deliberation dev mode container, outside of the static file server. Client-deliberation lives on port 8081 but the API lives on port 5000 so we introduced an option to force the API calls to be sent to that port